### PR TITLE
agregado de readme para pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,32 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+consideraciones a tener en cuenta:
+- 1 dia antes de la entrega, la api de mercadopago sufrió cambios en el comportamiento(no así en la documentación del funcionamiento), 
+y como lo explica la siguiente página "https://www.mercadopago.com.ar/developers/panel/app/8146148984937354/credentials/sandbox" solo se 
+puede probar el comportamiento de checkoutpro realizando pagos desde una cuenta de prueba a otra, por lo tanto se deberia crear una cuenta de prueba para probar el funcionamiento y usar una de las tarjetas de prueba. alternativamente, proveemos una cuenta y tarjetas de prueba para realizar el pago:
 
-## Getting Started
+usuario: TESTUSER1724715886
+password: jMtKIQxhEW
 
-First, run the development server:
+tarjeta: 5031 7557 3453 0604
+codigo: 123
+caducidad: 11/25
+nombre: APRO
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+-No sabemos exactamente cual es el comportamiento que se espera del pull request, pero no pudimos lograr que se muestren todos los cambios del 
+proyecto en el mismo, por ende hicimos un push extra con el readme para luego hacer el pull request sobre esa branch
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+- Link a produccion: https://bodine.vercel.app/ 
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- bugs conocidos: 
+    #1 El navbar no funciona correctamente en producción, el comportamiento deseado es el que se experimenta en un entorno local.
+    creemos que el error puede estar relacionado con la caché.
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+    #2 En la página de compras recibimos unos warnings que se deben a un atributo fixed que tiene el navbar, pero no podemos quitar el fixed ya que desaparece el logo en el scroll.
 
-## Learn More
+    #3 Todas las paginas tienen contenido clickeable. No pudimos hacer que no sea clickeable.
 
-To learn more about Next.js, take a look at the following resources:
+observaciones:
+    #1 Se decidió que no se puedan cliquear los vinos en la page principal y sea meramente visual.
+    #2 Si se intenta acceder a un vino que no existe mediante la url p.e: /vino/id=1700 se recibe una alerta informando que no existe.
+    #3 Por recomendación de nuestro ayudante asignado no modelamos las suscripciones en la base de datos, por lo tanto el apartado suscripciones no posee funcionalidades.
+    #4 El log para el admin está habilitado en producción, ya que en local hay un error relacionado con el csrf que no pudimos trackear correctamente.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.


### PR DESCRIPTION
consideraciones a tener en cuenta:
- 1 dia antes de la entrega, la api de mercadopago sufrió cambios en el comportamiento(no así en la documentación del funcionamiento), 
y como lo explica la siguiente página "https://www.mercadopago.com.ar/developers/panel/app/8146148984937354/credentials/sandbox" solo se 
puede probar el comportamiento de checkoutpro realizando pagos desde una cuenta de prueba a otra, por lo tanto se deberia crear una cuenta de prueba para probar el funcionamiento y usar una de las tarjetas de prueba. alternativamente, proveemos una cuenta y tarjetas de prueba para realizar el pago:

usuario: TESTUSER1724715886
password: jMtKIQxhEW

tarjeta: 5031 7557 3453 0604
codigo: 123
caducidad: 11/25
nombre: APRO

-No sabemos exactamente cual es el comportamiento que se espera del pull request, pero no pudimos lograr que se muestren todos los cambios del 
proyecto en el mismo, por ende hicimos un push extra con el readme para luego hacer el pull request sobre esa branch

- Link a produccion: https://bodine.vercel.app/ 

- bugs conocidos: 
    #1 El navbar no funciona correctamente en producción, el comportamiento deseado es el que se experimenta en un entorno local.
    creemos que el error puede estar relacionado con la caché.

    #2 En la página de compras recibimos unos warnings que se deben a un atributo fixed que tiene el navbar, pero no podemos quitar el fixed ya que desaparece el logo en el scroll.

    #3 Todas las paginas tienen contenido clickeable. No pudimos hacer que no sea clickeable.

observaciones:
    #1 Se decidió que no se puedan cliquear los vinos en la page principal y sea meramente visual.
    #2 Si se intenta acceder a un vino que no existe mediante la url p.e: /vino/id=1700 se recibe una alerta informando que no existe.
    #3 Por recomendación de nuestro ayudante asignado no modelamos las suscripciones en la base de datos, por lo tanto el apartado suscripciones no posee funcionalidades.
    #4 El log para el admin está habilitado en producción, ya que en local hay un error relacionado con el csrf que no pudimos trackear correctamente.

